### PR TITLE
feat: configure hiding of sign-up & related fields

### DIFF
--- a/ENV_SETUP.md
+++ b/ENV_SETUP.md
@@ -126,6 +126,11 @@ All configuration is stored in JSON format in the `portal2.json` file. See `port
 - `profile.warningPeriod` - Days before showing update warning
 - `profile.*Text` - User-facing messages
 
+### 🖥️ UI Settings
+- `externalRegistration` - Set this flag to true in the configuration
+    to remove any sign-up feature from your CyVerse Portal UI. This assumes
+    the User model is created by a third party service using the Portal API.
+
 
 ## Environment-Specific Setup
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ Edit your `portal2.json` file with the required settings:
   },
   "features": {
     "intercomEnabled": false
-  }
+  },
+  "externalRegistration": false
 }
 ```
 

--- a/next.config.js
+++ b/next.config.js
@@ -48,7 +48,8 @@ const publicRuntimeConfig = {
   INTERCOM_APP_ID: getConfigValue('intercom.appId'),
   INTERCOM_COMPANY_ID: getConfigValue('intercom.companyId'),
   TERRAIN_URL: getConfigValue('terrain.url'),
-  HONEYPOT_DIVISOR: getConfigValue('honeypot.divisor')
+  HONEYPOT_DIVISOR: getConfigValue('honeypot.divisor'),
+  EXTERNAL_REGISTRATION: getConfigValue('externalRegistration')
 }
 
 // Verify required configuration

--- a/portal2.template.json
+++ b/portal2.template.json
@@ -86,5 +86,6 @@
   },
   "honeypot": {
     "divisor": 7
-  }
+  },
+  "externalRegistration": false
 }

--- a/src/api/lib/config.js
+++ b/src/api/lib/config.js
@@ -291,6 +291,15 @@ class ConfigManager {
     }
 
     /**
+     * Get external registration flag
+     * @returns {Object} External registration config
+     */
+    getExternalRegistrationConfig() {
+        this.init()
+        return this._config.externalRegistration
+    }
+
+    /**
      * Get all configuration
      * @returns {Object} Complete configuration object
      */

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -10,6 +10,7 @@ import { APIProvider } from '../contexts/api'
 import { UserProvider } from '../contexts/user'
 import { ErrorProvider } from '../contexts/error'
 import { SuccessProvider } from '../contexts/success'
+import { ConfigProvider } from '../contexts/config'
 import Custom404 from './404'
 import Custom500 from './500'
 import getConfig from 'next/config'
@@ -43,7 +44,6 @@ function MyApp(props) {
         baseUrl,
         token,
     } = props
-
     // Added to handle errors from API during SSR
     if (pageProps.error) {
         console.log('Error in getServerSideProps:', pageProps.error)
@@ -72,22 +72,24 @@ function MyApp(props) {
             <Sentry.ErrorBoundary fallback={'An error has occurred'}>
                 <ThemeProvider theme={theme}>
                     <CssBaseline />
-                    <APIProvider baseUrl={baseUrl} token={token}>
-                        <UserProvider user={user}>
-                            <Head>
-                                <title>User Portal - CyVerse</title>
-                                <meta
-                                    name="viewport"
-                                    content="initial-scale=1, width=device-width"
-                                />
-                            </Head>
-                            <ErrorProvider>
-                                <SuccessProvider>
-                                    <Component {...pageProps} />
-                                </SuccessProvider>
-                            </ErrorProvider>
-                        </UserProvider>
-                    </APIProvider>
+                    <ConfigProvider config={publicRuntimeConfig}>
+                        <APIProvider baseUrl={baseUrl} token={token}>
+                            <UserProvider user={user}>
+                                <Head>
+                                    <title>User Portal - CyVerse</title>
+                                    <meta
+                                        name="viewport"
+                                        content="initial-scale=1, width=device-width"
+                                    />
+                                </Head>
+                                    <ErrorProvider>
+                                        <SuccessProvider>
+                                            <Component {...pageProps} />
+                                        </SuccessProvider>
+                                    </ErrorProvider>
+                            </UserProvider>
+                        </APIProvider>
+                    </ConfigProvider>
                 </ThemeProvider>
             </Sentry.ErrorBoundary>
         </CacheProvider>

--- a/src/pages/account.js
+++ b/src/pages/account.js
@@ -34,6 +34,7 @@ import { useAPI } from '../contexts/api'
 import { useError } from '../contexts/error'
 import { useSuccess } from '../contexts/success'
 import { useUser } from '../contexts/user'
+import { useConfig }  from '../contexts/config'
 import { sortCountries } from '../lib/misc'
 import { makeStyles } from '../styles/tss'
 const properties = require('../user-properties.json')
@@ -66,6 +67,7 @@ const Account = () => {
     const [_, setError] = useError()
     const [__, setSuccess] = useSuccess()
     const [user, setUser] = useUser()
+    const config = useConfig()
 
     // All useState hooks must be declared before any conditional returns
     const [sentEmails, setSentEmails] = useState([])
@@ -176,6 +178,7 @@ const Account = () => {
                 changeHandler,
                 inputHandler,
                 setInstitutions,
+                config,
             })
         )
     }, [
@@ -357,8 +360,42 @@ const getForms = ({
     changeHandler,
     inputHandler,
     setInstitutions,
+    config,
 }) => {
-    return [
+    const password_field = {
+        title: 'Password',
+        subtitle: (
+            <>
+                Reset your password <a href="/forgot">here</a> if you have
+                forgotten it
+            </>
+        ),
+        autosave: false,
+        hideReviewMode: true,
+        submitHandler: changeHandler,
+        fields: [
+            {
+                id: 'old_password',
+                name: 'Old Password',
+                type: 'password',
+                required: true,
+            },
+            {
+                id: 'new_password',
+                name: 'New Password',
+                type: 'password',
+                required: true,
+            },
+            {
+                id: 'confirm_password',
+                name: 'Confirm New Password',
+                type: 'password',
+                required: true,
+            },
+        ],
+    }
+    
+    const base_fields = [
         {
             title: 'Identification',
             autosave: true,
@@ -402,38 +439,6 @@ const getForms = ({
                     ),
                     type: 'text',
                     value: user.orcid_id,
-                },
-            ],
-        },
-        {
-            title: 'Password',
-            subtitle: (
-                <>
-                    Reset your password <a href="/forgot">here</a> if you have
-                    forgotten it
-                </>
-            ),
-            autosave: false,
-            hideReviewMode: true,
-            submitHandler: changeHandler,
-            fields: [
-                {
-                    id: 'old_password',
-                    name: 'Old Password',
-                    type: 'password',
-                    required: true,
-                },
-                {
-                    id: 'new_password',
-                    name: 'New Password',
-                    type: 'password',
-                    required: true,
-                },
-                {
-                    id: 'confirm_password',
-                    name: 'Confirm New Password',
-                    type: 'password',
-                    required: true,
                 },
             ],
         },
@@ -565,6 +570,7 @@ const getForms = ({
             ],
         },
     ]
+    return config.EXTERNAL_REGISTRATION ? base_fields : [...base_fields, password_field]
 }
 
 const EmailForm = ({ emails, title, subtitle, onChange }) => {

--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -136,6 +136,7 @@ const Right = props => {
     const query = router && router.query ? router.query : {}
 
     const [signup, setSignup] = useState(!!query.signup)
+    const [externalRegistration] = useState(query.externalRegistration && query.externalRegistration == "true")
     const [forgotPassword, setForgotPassword] = useState(!!query.forgot)
 
     if (forgotPassword)
@@ -156,21 +157,26 @@ const Right = props => {
                     Welcome to CyVerse!
                 </Typography>
             </Box>
-            <Box pt={'5em'}>
-                <Typography gutterBottom>New to CyVerse?</Typography>
-            </Box>
-            <Box>
-                <Button
-                    variant="contained"
-                    color="primary"
-                    size="large"
-                    disableElevation
-                    className={classes.button}
-                    onClick={() => setSignup(true)}
-                >
-                    Sign Up
-                </Button>
-            </Box>
+            
+            {!externalRegistration && (
+                <Box pt={'5em'}>
+                    <Typography gutterBottom>New to CyVerse?</Typography>
+                </Box>
+            )}
+            {!externalRegistration && (
+                <Box>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        size="large"
+                        disableElevation
+                        className={classes.button}
+                        onClick={() => setSignup(true)}
+                    >
+                        Sign Up
+                    </Button>
+                </Box>
+            )}
             <Box mt={5}>
                 <Button
                     variant="outlined"
@@ -183,15 +189,17 @@ const Right = props => {
                     Login
                 </Button>
             </Box>
-            <Box mt={7} mb={5}>
-                <Button
-                    variant="text"
-                    size="small"
-                    onClick={() => setForgotPassword(true)}
-                >
-                    Forgot Password
-                </Button>
-            </Box>
+            {!externalRegistration && (
+                <Box mt={7} mb={5}>
+                    <Button
+                        variant="text"
+                        size="small"
+                        onClick={() => setForgotPassword(true)}
+                    >
+                        Forgot Password
+                    </Button>
+                </Box>
+            )}
         </div>
     )
 }

--- a/src/server.js
+++ b/src/server.js
@@ -181,27 +181,31 @@ app.prepare()
             req.ws = sockets[username]
             next()
         })
-
+        
+        const externalRegistrationConfig = config.getExternalRegistrationConfig()
         // Default to landing page if not logged in
         server.get('/', keycloakClient.checkSso(), (req, res) => {
             const token = getUserToken(req)
-            if (token) res.redirect('/services')
-            else app.render(req, res, '/welcome')
+            if (token) res.redirect('/* /services */')
+            else app.render(req, res, '/welcome', { externalRegistration: externalRegistrationConfig })
         })
 
         // Public UI pages
-        server.get(['/signup', '/register'], (req, res) => {
-            app.render(req, res, '/welcome', { signup: 1 })
-        })
+        
+        if (!externalRegistrationConfig) {
+            server.get(['/signup', '/register'], (req, res) => {
+                app.render(req, res, '/welcome', { signup: 1 })
+            })
 
-        server.get(['/forgot', '/password/forgot'], (req, res) => {
-            // /password/forgot for old links from DE/CAS
-            app.render(req, res, '/welcome', { forgot: 1 })
-        })
+            server.get(['/forgot', '/password/forgot'], (req, res) => {
+                // /password/forgot for old links from DE/CAS
+                app.render(req, res, '/welcome', { forgot: 1 })
+            })
 
-        server.get('/password', (req, res) => {
-            app.render(req, res, '/password')
-        })
+            server.get('/password', (req, res) => {
+                app.render(req, res, '/password')
+            })
+        }
 
         server.get('/confirm_email', (req, res) => {
             app.render(req, res, '/confirm_email')


### PR DESCRIPTION
For usecases where the user registration normal flow through portal UI can be skipped (e.g. user is registered automatically by another service), add the posibility to hide any fields related to sign-up & registration.

This includes
- sign up button
- forgot password button
- password change in the Account dashboard

UI with flag enabled

<img width="2234" height="1249" alt="image" src="https://github.com/user-attachments/assets/7796f166-533d-4132-9a46-d51a4ff998ac" />

